### PR TITLE
feat: populate book admins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.1, 8.2]
+        php: [ 8.2, 8.3]
         wp: ['latest']
         mysql: [8.0]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,39 @@
 name: Testing
-
 on:
   push:
     branches: [ dev, production ]
   pull_request:
     branches: [ dev ]
-
 jobs:
-
   functional:
     name: Functional - WP ${{ matrix.wp }} on PHP ${{ matrix.php }} with MySQL ${{ matrix.mysql }}
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.2, 8.3]
+        php: [ 8.2 ]
         wp: ['latest']
-        mysql: [8.0]
+        mysql: ["8.0"]
     runs-on: ubuntu-latest
-
     services:
       mysql:
         image: mysql:${{ matrix.mysql }}
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: wp_cli_test
+          MYSQL_USER: wp_cli_test
+          MYSQL_PASSWORD: password1
         ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=wp_cli_test --entrypoint sh mysql:${{ matrix.mysql }} -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
-
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping -h localhost" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
       - name: Check existence of composer.json & behat.yml files
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
           files: "composer.json, behat.yml"
-
-      - name: Set up PHP envirnoment
+      - name: Set up PHP environment
         if: steps.check_files.outputs.files_exists == 'true'
         uses: shivammathur/setup-php@v2
         with:
@@ -43,15 +41,14 @@ jobs:
           extensions: mysql, zip
           coverage: none
           tools: composer
-
       - name: Get Composer cache Directory
         if: steps.check_files.outputs.files_exists == 'true'
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Use Composer cache
         if: steps.check_files.outputs.files_exists == 'true'
-        uses: actions/cache@master
+        uses: actions/cache@v4
         with:
           path: ${{ steps['composer-cache'].outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -60,21 +57,34 @@ jobs:
       - name: Install dependencies
         if: steps.check_files.outputs.files_exists == 'true'
         run: COMPOSER_ROOT_VERSION=dev-master composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Start MySQL server
+      - name: Install MySQL client
         if: steps.check_files.outputs.files_exists == 'true'
-        run: sudo systemctl start mysql
-
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mysql-client
+      - name: Wait for MySQL to be ready
+        if: steps.check_files.outputs.files_exists == 'true'
+        run: |
+          for i in {1..30}; do
+            if mysql -h 127.0.0.1 -P 3306 -u root -proot -e "SELECT 1" >/dev/null 2>&1; then
+              echo "MySQL is ready!"
+              break
+            fi
+            echo "Waiting for MySQL... (attempt $i)"
+            sleep 2
+          done
       - name: Configure DB environment
         if: steps.check_files.outputs.files_exists == 'true'
         run: |
-          export MYSQL_HOST=127.0.0.1
-          export MYSQL_TCP_PORT=${{ job.services.mysql.ports['3306'] }}
           echo "WP_CLI_TEST_DBROOTUSER=root" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBROOTPASS=root" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBUSER=wp_cli_test" >> $GITHUB_ENV
           echo "WP_CLI_TEST_DBPASS=password1" >> $GITHUB_ENV
-          echo "WP_CLI_TEST_DBHOST=$MYSQL_HOST:$MYSQL_TCP_PORT" >> $GITHUB_ENV
+          echo "WP_CLI_TEST_DBHOST=127.0.0.1:3306" >> $GITHUB_ENV
+          echo "MYSQL_PWD=root" >> $GITHUB_ENV
+          echo "MYSQL_HOST=127.0.0.1" >> $GITHUB_ENV
+          echo "MYSQL_TCP_PORT=3306" >> $GITHUB_ENV
+          
       - name: Prepare test database
         if: steps.check_files.outputs.files_exists == 'true'
         run: composer prepare-tests

--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ wp pb clone <source> <destination> --user=<user>
 	--user=<user>
 		sets request to a specific WordPress user
 
+### wp pb populate-books-admins
+It populates `pb_book_admins` blog metada for each blog with comma-separated book administrator's user IDs.
+
 ## Installing
 
 Installing this package requires WP-CLI v2.5.0 or greater. Update to the latest stable release with `wp cli update`.

--- a/command.php
+++ b/command.php
@@ -18,4 +18,5 @@ WP_CLI::add_command( 'pb issue-template', [ 'Pressbooks_CLI\IssueTemplateCommand
 WP_CLI::add_command( 'pb theme lock', [ 'Pressbooks_CLI\ThemeLockCommand', 'lock' ] );
 WP_CLI::add_command( 'pb theme unlock', [ 'Pressbooks_CLI\ThemeLockCommand', 'unlock' ] );
 WP_CLI::add_command( 'pb clone', [ 'Pressbooks_CLI\CloneCommand', 'clone' ] );
+WP_CLI::add_command('pb populate-books-admins', ['Pressbooks_CLI\PopulateBooksAdminsCommand', 'populate']);
 

--- a/inc/PopulateBooksAdminsCommand.php
+++ b/inc/PopulateBooksAdminsCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pressbooks_CLI;
+
+use WP_CLI;
+
+use Pressbooks\DataCollector\Book;
+
+class PopulateBooksAdminsCommand extends PB_CLI_Command {
+    /**
+     * Populate book admins.
+     *
+     * ## OPTIONS
+     *
+     * @when after_wp_load
+     *
+     * @param array $args
+     * @param array $assoc_args
+     */
+    public function populate( $args, $assoc_args ) {
+
+        if ( ! is_multisite() ) {
+            return;
+        }
+
+        // populate pb_book_admins blogmeta for all books using updateAllBooksAdmins function
+        $bookCollector = new Book();
+        $bookCollector->updateAllBooksAdmins();
+
+        WP_CLI::success( 'Book admins populated successfully.' );
+
+    }
+}


### PR DESCRIPTION
Requires: https://github.com/pressbooks/pressbooks/pull/4017

This pull request introduces a new WP-CLI command, `pb populate-books-admins`, to populate book administrators' metadata across all blogs in a multisite WordPress setup. The changes include adding the command, implementing its functionality, and documenting its usage.

### New Command Addition:

* **Command registration**: Added a new WP-CLI command, `pb populate-books-admins`, in `command.php`. This command is linked to the `PopulateBooksAdminsCommand` class.
* **Command implementation**: Created the `PopulateBooksAdminsCommand` class in a new file, `inc/PopulateBooksAdminsCommand.php`. This class defines the `populate` method, which updates the `pb_book_admins` blog metadata for all blogs using the `updateAllBooksAdmins` method from the `Pressbooks\DataCollector\Book` class.

### Documentation Update:

* **README update**: Added documentation for the `pb populate-books-admins` command in `README.md`, explaining its purpose and usage.